### PR TITLE
Axes labels do not react to template variables changes #94

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -742,7 +742,7 @@ class PlotlyPanelCtrl extends MetricsPanelCtrl {
     if (this.annotations.shapes.length > 0) {
       traces = this.traces.concat(this.annotations.trace);
     }
-    console.log('ConfigChanged (traces)', traces);
+
     Plotly.react(this.graphDiv, traces, this.layout, options);
   }
 

--- a/src/module.ts
+++ b/src/module.ts
@@ -424,7 +424,7 @@ class PlotlyPanelCtrl extends MetricsPanelCtrl {
 
     const isLayoutChanged = !_.isEqual(this.layout, this.getProcessedLayout());
     if (!this.initialized || isLayoutChanged) {
-      this.plotlyReact();
+      this.createOrUpdatePlot();
 
       this.graphDiv.on('plotly_click', data => {
         if (data === undefined || data.points === undefined) {
@@ -726,7 +726,7 @@ class PlotlyPanelCtrl extends MetricsPanelCtrl {
     return true;
   }
 
-  plotlyReact() {
+  createOrUpdatePlot(): void {
     const s = this.cfg.settings;
 
     const options = {
@@ -768,7 +768,7 @@ class PlotlyPanelCtrl extends MetricsPanelCtrl {
         if (!this.cfg.showAnnotations) {
           this.annotations.clear();
         }
-        this.plotlyReact();
+        this.createOrUpdatePlot();
       }
 
       this.render(); // does not query again!

--- a/src/module.ts
+++ b/src/module.ts
@@ -422,23 +422,9 @@ class PlotlyPanelCtrl extends MetricsPanelCtrl {
       return;
     }
 
-    if (!this.initialized) {
-      const s = this.cfg.settings;
-
-      const options = {
-        showLink: false,
-        displaylogo: false,
-        displayModeBar: s.displayModeBar,
-        modeBarButtonsToRemove: ['sendDataToCloud'], //, 'select2d', 'lasso2d']
-      };
-
-      this.layout = this.getProcessedLayout();
-      this.layout.shapes = this.annotations.shapes;
-      let traces = this.traces;
-      if (this.annotations.shapes.length > 0) {
-        traces = this.traces.concat(this.annotations.trace);
-      }
-      Plotly.react(this.graphDiv, traces, this.layout, options);
+    const isLayoutChanged = !_.isEqual(this.layout, this.getProcessedLayout());
+    if (!this.initialized || isLayoutChanged) {
+      this.plotlyReact();
 
       this.graphDiv.on('plotly_click', data => {
         if (data === undefined || data.points === undefined) {
@@ -740,6 +726,26 @@ class PlotlyPanelCtrl extends MetricsPanelCtrl {
     return true;
   }
 
+  plotlyReact() {
+    const s = this.cfg.settings;
+
+    const options = {
+      showLink: false,
+      displaylogo: false,
+      displayModeBar: s.displayModeBar,
+      modeBarButtonsToRemove: ['sendDataToCloud'], //, 'select2d', 'lasso2d']
+    };
+
+    this.layout = this.getProcessedLayout();
+    this.layout.shapes = this.annotations.shapes;
+    let traces = this.traces;
+    if (this.annotations.shapes.length > 0) {
+      traces = this.traces.concat(this.annotations.trace);
+    }
+    console.log('ConfigChanged (traces)', traces);
+    Plotly.react(this.graphDiv, traces, this.layout, options);
+  }
+
   onConfigChanged() {
     // Force reloading the traces
     this._updateTraceData(true);
@@ -762,22 +768,7 @@ class PlotlyPanelCtrl extends MetricsPanelCtrl {
         if (!this.cfg.showAnnotations) {
           this.annotations.clear();
         }
-
-        const s = this.cfg.settings;
-        const options = {
-          showLink: false,
-          displaylogo: false,
-          displayModeBar: s.displayModeBar,
-          modeBarButtonsToRemove: ['sendDataToCloud'], //, 'select2d', 'lasso2d']
-        };
-        this.layout = this.getProcessedLayout();
-        this.layout.shapes = this.annotations.shapes;
-        let traces = this.traces;
-        if (this.annotations.shapes.length > 0) {
-          traces = this.traces.concat(this.annotations.trace);
-        }
-        console.log('ConfigChanged (traces)', traces);
-        Plotly.react(this.graphDiv, traces, this.layout, options);
+        this.plotlyReact();
       }
 
       this.render(); // does not query again!


### PR DESCRIPTION
This PR fixes the problem that axes labels do not react to template variables changes.

When you change a template variable, only metrics are re-rendered. Axes are re-rendered only when you change panel config. 

## Changes:
 - `onRender()`:  re-render the whole plot (not only metrics) if layout is changed (axes labels are part of layout).

## Other changes:
 - move duplicated code from `onConfigChanged()` and `onRender()` to new `createOrUpdatePlot()` method